### PR TITLE
Allow updating attributes through Stack#add

### DIFF
--- a/lib/humidifier/resource.rb
+++ b/lib/humidifier/resource.rb
@@ -44,6 +44,14 @@ module Humidifier
       properties.each { |property, value| update_property(property, value, raw) }
     end
 
+    # Update the attributes of the resource defined by COMMON_ATTRIBUTES
+    def update_attributes(attributes)
+      attributes.each do |attribute, value|
+        raise ArgumentError, "Invalid attribute: #{attribute}" unless COMMON_ATTRIBUTES.value?(attribute)
+        public_send(:"#{attribute}=", value)
+      end
+    end
+
     # Update an individual property on this resource
     def update_property(property, value, raw = false)
       property = property.to_s

--- a/lib/humidifier/stack.rb
+++ b/lib/humidifier/stack.rb
@@ -19,9 +19,11 @@ module Humidifier
       STATIC_RESOURCES.values.each { |prop| send(:"#{prop}=", opts[prop]) }
     end
 
-    # Add a resource to the stack
-    def add(name, resource)
+    # Add a resource to the stack and optionally set its attributes
+    def add(name, resource, attributes = {})
       resources[name] = resource
+      resource.update_attributes(attributes) if attributes.any?
+      resource
     end
 
     # The identifier used by the shim to find the stack in CFN, prefers id to name

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -53,6 +53,14 @@ class ResourceTest < Minitest::Test
     assert_equal ({ 'one' => 'three', 'two' => 4 }), resource.properties
   end
 
+  def test_update_attributes
+    resource = build
+    resource.update_attributes(condition: 'foo', creation_policy: 'bar')
+
+    assert_equal 'foo', resource.condition
+    assert_equal 'bar', resource.creation_policy
+  end
+
   def test_update_property
     resource = build
     resource.update_property('one', 'three')

--- a/test/stack_test.rb
+++ b/test/stack_test.rb
@@ -20,6 +20,16 @@ class StackTest < Minitest::Test
     assert_equal ({ 'MyResource' => resource }), stack.resources
   end
 
+  def test_add_with_attributes
+    attributes = %w[alpha beta]
+    mock = Minitest::Mock.new
+    mock.expect(:update_attributes, nil, [attributes])
+
+    stack = Humidifier::Stack.new
+    stack.add('MyResource', mock, attributes)
+    assert_mock mock
+  end
+
   def test_add_condition
     stack = Humidifier::Stack.new
     stack.add_condition('foo', Humidifier.fn.if('Bar'))


### PR DESCRIPTION
You can now update the common attributes of a resource through Stack#add, as in:

    stack = Humidifier::Stack.new
    stack.add('SG', Humidifier::EC2::SecurityGroup.new, deletion_policy: 'Retain')

Fixes #45 