### PR TITLE
Large templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ Humidifier itself contains a registry of all possible resources that it supports
 
 Resources have an `aws_name` method to see how AWS references them. They also contain a `props` method that contains a hash of the name that Humidifier uses to reference the prop pointing to the appropriate prop object.
 
+### Large templates
+
+When templates are especially large (larger than 51,200 bytes), they cannot be uploaded directly through the AWS SDK. You can configure Humidifier to seemlessly upload the templates to S3 and reference them using an S3 URL instead by:
+
+```ruby
+Humidifier.configure do |config|
+  config.s3_bucket = 'my.s3.bucket'
+  config.s3_prefix = 'my-prefix/' # optional
+end
+```
+
 ## Development
 
 To get started, ensure you have ruby installed, version 2.0 or later. From there, install the `bundler` gem: `gem install bundler` and then `bundle install` in the root of the repository.

--- a/lib/humidifier.rb
+++ b/lib/humidifier.rb
@@ -11,6 +11,7 @@ require 'humidifier/props'
 
 require 'humidifier/aws_shim'
 require 'humidifier/condition'
+require 'humidifier/configuration'
 require 'humidifier/loader'
 require 'humidifier/mapping'
 require 'humidifier/output'
@@ -25,6 +26,16 @@ require 'humidifier/version'
 # container module for all gem classes
 module Humidifier
   class << self
+    # the configuration instance
+    def config
+      @config ||= Configuration.new
+    end
+
+    # yield the config object to the block for setting user params
+    def configure
+      yield config
+    end
+
     # convenience method for calling cloudformation functions
     def fn
       Fn

--- a/lib/humidifier/aws_adapters/base.rb
+++ b/lib/humidifier/aws_adapters/base.rb
@@ -31,6 +31,12 @@ module Humidifier
         try_valid { client.update_stack(payload.update_params) }
       end
 
+      # Upload a CFN stack to S3 so that it can be referenced via template_url
+      def upload(payload)
+        Humidifier.config.ensure_upload_configured!(payload)
+        upload_object(payload, "#{Humidifier.config.s3_prefix}#{payload.identifier}.json")
+      end
+
       # Validate a template in CFN
       def valid?(payload)
         try_valid { client.validate_template(payload.validate_params) }

--- a/lib/humidifier/aws_adapters/sdkv1.rb
+++ b/lib/humidifier/aws_adapters/sdkv1.rb
@@ -47,6 +47,12 @@ module Humidifier
         response
       end
 
+      def upload_object(payload, key)
+        base_module.config(region: AwsShim::REGION)
+        @s3 ||= base_module::S3.new
+        @s3.buckets[Humidifier.config.s3_bucket].objects.create(key, payload.template_body).url_for(:read)
+      end
+
       def unsupported(method)
         puts "WARNING: Cannot #{method} because that functionality is not supported in V1 of aws-sdk."
         false

--- a/lib/humidifier/aws_adapters/sdkv2.rb
+++ b/lib/humidifier/aws_adapters/sdkv2.rb
@@ -37,6 +37,13 @@ module Humidifier
 
         response
       end
+
+      def upload_object(payload, key)
+        base_module.config.update(region: AwsShim::REGION)
+        @s3_client ||= base_module::S3::Client.new
+        @s3_client.put_object(body: payload.template_body, bucket: Humidifier.config.s3_bucket, key: key)
+        base_module::S3::Object.new(Humidifier.config.s3_bucket, key).presigned_url(:get)
+      end
     end
   end
 end

--- a/lib/humidifier/aws_shim.rb
+++ b/lib/humidifier/aws_shim.rb
@@ -13,7 +13,7 @@ module Humidifier
 
     # Methods that are sent over to the aws adapter from the stack
     STACK_METHODS = %i[
-      create delete deploy exists? update valid?
+      create delete deploy exists? update upload valid?
       create_and_wait delete_and_wait deploy_and_wait update_and_wait
       create_change_set deploy_change_set
     ].freeze

--- a/lib/humidifier/configuration.rb
+++ b/lib/humidifier/configuration.rb
@@ -10,11 +10,11 @@ on the top-level Humidifier object like so:
 
     Humidifier.configure do |config|
       config.s3_bucket = 'my.s3.bucket'
-      config.s3_path = 'my-prefix' # optional
+      config.s3_prefix = 'my-prefix' # optional
     end
 MSG
 
-    attr_accessor :s3_bucket, :s3_path
+    attr_accessor :s3_bucket, :s3_prefix
 
     # raise an error unless the s3_bucket field is set
     def ensure_upload_configured!(payload)

--- a/lib/humidifier/configuration.rb
+++ b/lib/humidifier/configuration.rb
@@ -1,0 +1,24 @@
+module Humidifier
+
+  # a container for user params
+  class Configuration
+
+    UPLOAD_MESSAGE = <<-MSG
+The %{identifier} stack's body is too large to be use the template_body option, and therefore must use the
+template_url option instead. You can configure Humidifier to do this automatically by setting up the s3 config
+on the top-level Humidifier object like so:
+
+    Humidifier.configure do |config|
+      config.s3_bucket = 'my.s3.bucket'
+      config.s3_path = 'my-prefix' # optional
+    end
+MSG
+
+    attr_accessor :s3_bucket, :s3_path
+
+    # raise an error unless the s3_bucket field is set
+    def ensure_upload_configured!(payload)
+      raise UPLOAD_MESSAGE.gsub('%{identifier}', payload.identifier) if s3_bucket.nil?
+    end
+  end
+end

--- a/lib/humidifier/configuration.rb
+++ b/lib/humidifier/configuration.rb
@@ -10,7 +10,7 @@ on the top-level Humidifier object like so:
 
     Humidifier.configure do |config|
       config.s3_bucket = 'my.s3.bucket'
-      config.s3_prefix = 'my-prefix' # optional
+      config.s3_prefix = 'my-prefix/' # optional
     end
 MSG
 

--- a/lib/humidifier/configuration.rb
+++ b/lib/humidifier/configuration.rb
@@ -3,7 +3,7 @@ module Humidifier
   # a container for user params
   class Configuration
 
-    UPLOAD_MESSAGE = <<-MSG
+    UPLOAD_MESSAGE = <<-MSG.freeze
 The %{identifier} stack's body is too large to be use the template_body option, and therefore must use the
 template_url option instead. You can configure Humidifier to do this automatically by setting up the s3 config
 on the top-level Humidifier object like so:
@@ -15,6 +15,11 @@ on the top-level Humidifier object like so:
 MSG
 
     attr_accessor :s3_bucket, :s3_prefix
+
+    def initialize(opts = {})
+      self.s3_bucket = opts[:s3_bucket]
+      self.s3_prefix = opts[:s3_prefix]
+    end
 
     # raise an error unless the s3_bucket field is set
     def ensure_upload_configured!(payload)

--- a/lib/humidifier/sdk_payload.rb
+++ b/lib/humidifier/sdk_payload.rb
@@ -6,6 +6,9 @@ module Humidifier
     # The maximum size a template body can be before it has to be put somewhere and referenced through a URL
     MAX_TEMPLATE_BODY_SIZE = 51_200
 
+    # The maximum size a template body can be inside of an S3 bucket
+    MAX_TEMPLATE_URL_SIZE = 460_800
+
     # The maximum amount of time that Humidifier should wait for a stack to complete a CRUD operation
     MAX_WAIT = 600
 
@@ -68,10 +71,12 @@ module Humidifier
 
     def template_param
       @template_param ||=
-        if template_body.bytesize < MAX_TEMPLATE_BODY_SIZE
-          { template_body: template_body }
-        else
+        if template_body.bytesize > MAX_TEMPLATE_URL_SIZE
+          raise "Cannot use a template > #{MAX_TEMPLATE_URL_SIZE} bytes (currently #{template_body.bytesize} bytes)"
+        elsif template_body.bytesize > MAX_TEMPLATE_BODY_SIZE
           { template_url: AwsShim.upload(self) }
+        else
+          { template_body: template_body }
         end
     end
   end

--- a/lib/humidifier/sdk_payload.rb
+++ b/lib/humidifier/sdk_payload.rb
@@ -3,6 +3,9 @@ module Humidifier
   # The payload sent to the shim methods, representing the stack and the options
   class SdkPayload
 
+    # The maximum size a template body can be before it has to be put somewhere and referenced through a URL
+    MAX_TEMPLATE_BODY_SIZE = 51200
+
     # The maximum amount of time that Humidifier should wait for a stack to complete a CRUD operation
     MAX_WAIT = 600
 
@@ -33,12 +36,12 @@ module Humidifier
 
     # Param set for the #create_change_set SDK method
     def create_change_set_params
-      { stack_name: stack.identifier, template_body: stack.to_cf }.merge(options)
+      { stack_name: stack.identifier, template_body: template_body }.merge(options)
     end
 
     # Param set for the #create_stack SDK method
     def create_params
-      { stack_name: stack.name, template_body: stack.to_cf }.merge(options)
+      { stack_name: stack.name, template_body: template_body }.merge(options)
     end
 
     # Param set for the #delete_stack SDK method
@@ -48,12 +51,22 @@ module Humidifier
 
     # Param set for the #update_stack SDK method
     def update_params
-      { stack_name: stack.identifier, template_body: stack.to_cf }.merge(options)
+      { stack_name: stack.identifier, template_body: template_body }.merge(options)
     end
 
     # Param set for the #validate_template SDK method
     def validate_params
-      { template_body: stack.to_cf }.merge(options)
+      { template_body: template_body }.merge(options)
+    end
+
+    private
+
+    def template_body
+      @template_body ||= stack.to_cf
+    end
+
+    def upload_required?
+      template_body.bytesize > MAX_TEMPLATE_BODY_SIZE
     end
   end
 end

--- a/lib/humidifier/sdk_payload.rb
+++ b/lib/humidifier/sdk_payload.rb
@@ -4,7 +4,7 @@ module Humidifier
   class SdkPayload
 
     # The maximum size a template body can be before it has to be put somewhere and referenced through a URL
-    MAX_TEMPLATE_BODY_SIZE = 51200
+    MAX_TEMPLATE_BODY_SIZE = 51_200
 
     # The maximum amount of time that Humidifier should wait for a stack to complete a CRUD operation
     MAX_WAIT = 600

--- a/test/aws_adapters/base_test.rb
+++ b/test/aws_adapters/base_test.rb
@@ -63,6 +63,18 @@ class BaseTest < Minitest::Test
     end
   end
 
+  def test_upload_configured
+    fake_sdk = Class.new(Humidifier::AwsAdapters::Base) do
+      def upload_object(_, key)
+        key
+      end
+    end
+
+    with_config('test.s3.bucket', 'prefix/') do
+      assert_equal 'prefix/name.json', fake_sdk.new.upload(payload(identifier: 'name'))
+    end
+  end
+
   def test_valid?
     with_both_sdks do |sdk|
       SdkSupport.expect(:validate_template, [{ template_body: 'body' }])

--- a/test/aws_adapters/sdkv1_test.rb
+++ b/test/aws_adapters/sdkv1_test.rb
@@ -54,6 +54,16 @@ class SDKV1Test < Minitest::Test
     end
   end
 
+  def test_upload
+    with_config('test.s3.bucket') do
+      with_sdk_v1_loaded do |sdk|
+        upload_expectations
+        sdk.upload(payload(identifier: 'identifier', to_cf: 'body'))
+        SdkSupport.verify
+      end
+    end
+  end
+
   private
 
   def create_and_wait_failure_expectations
@@ -64,5 +74,14 @@ class SDKV1Test < Minitest::Test
 
     events_response = stub(stack_events: [stub(resource_status: 'FAILED', resource_status_reason: 'failure')])
     SdkSupport.expect(:describe_stack_events, [{ stack_name: 'test-id' }], events_response)
+  end
+
+  def upload_expectations
+    SdkSupport.expect(:config, [region: Humidifier::AwsShim::REGION])
+    SdkSupport.expect(:new, [], SdkSupport.double)
+    SdkSupport.expect(:buckets, [], 'test.s3.bucket' => SdkSupport.double)
+    SdkSupport.expect(:objects, [], SdkSupport.double)
+    SdkSupport.expect(:create, ['identifier.json', 'body'], SdkSupport.double)
+    SdkSupport.expect(:url_for, [:read])
   end
 end

--- a/test/aws_adapters/sdkv2_test.rb
+++ b/test/aws_adapters/sdkv2_test.rb
@@ -64,6 +64,19 @@ class SDKV2Test < Minitest::Test
     end
   end
 
+  def test_upload
+    with_config('test.s3.bucket') do
+      with_sdk_v2_loaded do |sdk|
+        SdkSupport.expect(:config, [], SdkSupport.double)
+        SdkSupport.expect(:update, [region: Humidifier::AwsShim::REGION])
+        SdkSupport.expect(:put_object, [body: 'body', bucket: 'test.s3.bucket', key: 'identifier.json'])
+        SdkSupport.expect(:presigned_url, [:get])
+        sdk.upload(payload(identifier: 'identifier', to_cf: 'body'))
+        SdkSupport.verify
+      end
+    end
+  end
+
   private
 
   def change_set_options

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class ConfigurationTest < Minitest::Test
+
+  def test_ensure_upload_configured!
+    config = Humidifier::Configuration.new
+    error =
+      assert_raises RuntimeError do
+        config.ensure_upload_configured!(payload(identifier: 'foobar'))
+      end
+    assert_match(/foobar/, error.message)
+  end
+
+  def test_ensure_upload_configured_passes
+    config = Humidifier::Configuration.new
+    config.s3_bucket = Object.new
+    config.ensure_upload_configured!(payload(identifier: 'foobar'))
+  end
+end

--- a/test/humidifier_test.rb
+++ b/test/humidifier_test.rb
@@ -2,6 +2,16 @@ require 'test_helper'
 
 class HumidifierTest < Minitest::Test
 
+  def test_config
+    assert_kind_of Humidifier::Configuration, Humidifier.config
+  end
+
+  def test_configure
+    Humidifier.configure do |config|
+      assert_kind_of Humidifier::Configuration, config
+    end
+  end
+
   def test_fn
     assert_equal Humidifier::Fn, Humidifier.fn
   end

--- a/test/sdk_payload_test.rb
+++ b/test/sdk_payload_test.rb
@@ -53,6 +53,13 @@ class SdkPayloadTest < Minitest::Test
     end
   end
 
+  def test_template_param_extra_large
+    template_body = 'a' * (Humidifier::SdkPayload::MAX_TEMPLATE_URL_SIZE + 1)
+    assert_raises RuntimeError do
+      build(template_body).send(:template_param)
+    end
+  end
+
   private
 
   def build(template_body = 'to_cf')

--- a/test/sdk_payload_test.rb
+++ b/test/sdk_payload_test.rb
@@ -55,9 +55,11 @@ class SdkPayloadTest < Minitest::Test
 
   def test_template_param_extra_large
     template_body = 'a' * (Humidifier::SdkPayload::MAX_TEMPLATE_URL_SIZE + 1)
-    assert_raises RuntimeError do
-      build(template_body).send(:template_param)
-    end
+    error =
+      assert_raises Humidifier::SdkPayload::TemplateTooLargeError do
+        build(template_body).send(:template_param)
+      end
+    assert_match(/#{Humidifier::SdkPayload::MAX_TEMPLATE_URL_SIZE + 1} bytes/, error.message)
   end
 
   private

--- a/test/sdk_support/aws_double.rb
+++ b/test/sdk_support/aws_double.rb
@@ -1,25 +1,51 @@
 module SdkSupport
+  def self.double
+    AwsDouble
+  end
+
+  module ForwardMissing
+    def method_missing(method, *args, &block)
+      SdkSupport.call(method, args, &block)
+    end
+  end
+
   module AwsDouble
+    extend ForwardMissing
+
     module CloudFormation
       module Errors
         class ValidationError < StandardError; end
       end
 
       class Client
-        def initialize(*)
-        end
+        include ForwardMissing
 
-        def method_missing(method, *args, &block)
-          SdkSupport.call(method, args, &block)
+        def initialize(*)
         end
       end
 
       class Stack
+        include ForwardMissing
+
         def initialize(*)
         end
+      end
+    end
 
-        def method_missing(method, *args, &block)
-          SdkSupport.call(method, args, &block)
+    module S3
+      extend ForwardMissing
+
+      class Client
+        include ForwardMissing
+
+        def initialize(*)
+        end
+      end
+
+      class Object
+        include ForwardMissing
+
+        def initialize(*)
         end
       end
     end

--- a/test/stack_test.rb
+++ b/test/stack_test.rb
@@ -3,7 +3,10 @@ require 'test_helper'
 class StackTest < Minitest::Test
 
   def test_defaults
+    reset_stack_count
     stack = Humidifier::Stack.new
+
+    assert_match(/1\z/, stack.identifier)
     Humidifier::Stack::STATIC_RESOURCES.values.each do |prop|
       assert_equal nil, stack.send(prop)
     end
@@ -82,7 +85,18 @@ class StackTest < Minitest::Test
     end
   end
 
+  def test_class_next_default_identifier
+    reset_stack_count
+    (1..5).each do |num|
+      assert_match(/#{num}\z/, Humidifier::Stack.next_default_identifier)
+    end
+  end
+
   private
+
+  def reset_stack_count
+    Humidifier::Stack.instance_variable_set(:@count, nil)
+  end
 
   def with_mocked_aws_shim(method)
     stack = Humidifier::Stack.new(name: 'test-stack')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,8 +29,13 @@ end
 Dir[File.expand_path('../sdk_support/*.rb', __FILE__)].each { |file| require file }
 Minitest::Test.send(:include, SdkSupport::Helpers)
 
-# include the ability to mock the serializer in tests
+# extra methods for testing config and serializers
 Minitest::Test.send(:include, Module.new do
+  def with_config(s3_bucket, s3_prefix = nil, &block)
+    config = Humidifier::Configuration.new(s3_bucket: s3_bucket, s3_prefix: s3_prefix)
+    Humidifier.stub(:config, config, &block)
+  end
+
   def with_mocked_serializer(value)
     mock = Minitest::Mock.new
     mock.expect(:call, value, [value])


### PR DESCRIPTION
This PR supports templates that are larger than 51200 bytes (the limit for using template_body). If you configure Humidifier like so:

    Humidifier.configure do |config|
      config.s3_bucket = 'my.s3.bucket'
    end

it will automatically upload the json templates to that bucket and use the resulting template_url. Also provided is the optional to set `s3_prefix` which will prefix the keys of any s3 objects being uploaded.