### PR TITLE
Make stack creation response have 'id' property

### DIFF
--- a/lib/humidifier/aws_adapters/sdkv2.rb
+++ b/lib/humidifier/aws_adapters/sdkv2.rb
@@ -20,11 +20,7 @@ module Humidifier
 
       # Create a change set if the stack exists, otherwise create the stack
       def deploy_change_set(payload)
-        if exists?(payload)
-          create_change_set(payload)
-        else
-          create(payload).instance_eval { ResponseWrapper.new(self) }
-        end
+        exists?(payload) ? create_change_set(payload) : ResponseWrapper.new(create(payload))
       end
 
       # True if the stack exists in CFN

--- a/lib/humidifier/aws_adapters/sdkv2.rb
+++ b/lib/humidifier/aws_adapters/sdkv2.rb
@@ -12,7 +12,7 @@ module Humidifier
 
       # Wrap the result from create_stack so it responds to :id in addition to
       # :stack_id
-      ResponseWrapper = Struct.new(:stack_id) do
+      class ResponseWrapper < SimpleDelegator
         def id
           stack_id
         end
@@ -23,7 +23,7 @@ module Humidifier
         if exists?(payload)
           create_change_set(payload)
         else
-          create(payload).instance_eval { ResponseWrapper.new(stack_id) }
+          create(payload).instance_eval { ResponseWrapper.new(self) }
         end
       end
 


### PR DESCRIPTION
This is so it conforms to the api of change set creation.