### PR TITLE
Add Number property.

### DIFF
--- a/lib/humidifier/props.rb
+++ b/lib/humidifier/props.rb
@@ -97,6 +97,20 @@ module Humidifier
       end
     end
 
+    # An number property
+    class NumberProp < Base
+      # converts the value through #to_i unless it is whitelisted
+      def convert(value)
+        puts "WARNING: Property #{name} should be a number" unless valid?(value)
+        value.to_i
+      end
+
+      # true if it is whitelisted or a Integer
+      def valid?(value)
+        whitelisted_value?(value) || value.is_a?(Integer)
+      end
+    end
+
     class << self
       # builds the appropriate prop object from the given spec line
       def from(spec_line)
@@ -106,6 +120,7 @@ module Humidifier
         when 'Boolean' then BooleanProp.new(key)
         when 'Integer' then IntegerProp.new(key)
         when 'String' then StringProp.new(key)
+        when 'Number' then NumberProp.new(key)
         when /\[.*?\]/ then ArrayProp.new(key)
         else JSONProp.new(key)
         end

--- a/test/props/number_prop_test.rb
+++ b/test/props/number_prop_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+module Props
+  class NumberPropTest < Minitest::Test
+
+    def test_valid?
+      assert Humidifier::Props::NumberProp.new.valid?(1)
+      assert Humidifier::Props::StringProp.new.valid?(Humidifier.ref(Object.new))
+      assert Humidifier::Props::StringProp.new.valid?(Humidifier.fn.base64(Object.new))
+    end
+
+    def test_rejects_other_values
+      refute Humidifier::Props::NumberProp.new.valid?(Object.new)
+      refute Humidifier::Props::NumberProp.new.valid?([])
+      refute Humidifier::Props::NumberProp.new.valid?({})
+      refute Humidifier::Props::NumberProp.new.valid?(1.0)
+    end
+
+    def test_convert_valid
+      assert_equal 5, Humidifier::Props::NumberProp.new.convert(5)
+    end
+
+    def test_convert_invalid
+      out, * = capture_io do
+        assert_equal 6, Humidifier::Props::NumberProp.new('Test').convert('6')
+      end
+      assert_match(/WARNING: Property test/, out)
+    end
+  end
+end


### PR DESCRIPTION
I added Number type for property because it is used by some specs. For example AWS::EC2::CustomerGateway, AWS::EC2::DHCPOptions, AWS::EC2::Volume, AWS::RDS::DBInstance.