### PR TITLE
Update specs to 2016-09-20

### DIFF
--- a/bin/get-specs
+++ b/bin/get-specs
@@ -29,5 +29,7 @@ Nokogiri::HTML(get_url('aws-template-resource-type-ref.html')).css('.highlights 
     CF
   end
 
-  File.write(File.join('specs', aws_name.scan(/AWS::(.*?)::(.*?)(?:\z|")/).first.join('-') + '.cf'), specs)
+  scanned = aws_name.scan(/AWS::(.*?)::(.*?)(?:\z|")/).first
+  scanned = %w[CloudFormation CustomResource] if scanned.nil?
+  File.write(File.join('specs', scanned.join('-') + '.cf'), specs)
 end

--- a/lib/humidifier.rb
+++ b/lib/humidifier.rb
@@ -1,6 +1,7 @@
 require 'forwardable'
 require 'json'
 require 'pathname'
+require 'yaml'
 
 require 'humidifier/humidifier'
 require 'humidifier/utils'

--- a/lib/humidifier/stack.rb
+++ b/lib/humidifier/stack.rb
@@ -33,8 +33,13 @@ module Humidifier
     end
 
     # A string representation of the stack that's valid for CFN
-    def to_cf
-      JSON.pretty_generate(enumerable_resources.merge(static_resources))
+    def to_cf(serializer = :json)
+      resources = static_resources.merge(enumerable_resources)
+
+      case serializer
+      when :json then JSON.pretty_generate(resources)
+      when :yaml then YAML.dump(resources)
+      end
     end
 
     %i[condition mapping output parameter].each do |resource_type|

--- a/lib/humidifier/version.rb
+++ b/lib/humidifier/version.rb
@@ -1,4 +1,4 @@
 module Humidifier
   # Gem version
-  VERSION = '0.5.0'.freeze
+  VERSION = '0.6.0'.freeze
 end

--- a/specs/ApiGateway-Account.cf
+++ b/specs/ApiGateway-Account.cf
@@ -1,6 +1,6 @@
 {
   "Type" : "AWS::ApiGateway::Account",
   "Properties" : {
-    "CloudWatchRoleArn" : String
+    "CloudWatchRoleArn": String
   }
 }

--- a/specs/AutoScaling-AutoScalingGroup.cf
+++ b/specs/AutoScaling-AutoScalingGroup.cf
@@ -1,22 +1,22 @@
 {
-  "Type" : "AWS::AutoScaling::AutoScalingGroup",
-  "Properties" : {
-    "AvailabilityZones" : [ String, ... ],
-    "Cooldown" : String,
-    "DesiredCapacity" : String,
-    "HealthCheckGracePeriod" : Integer,
-    "HealthCheckType" : String,
-    "InstanceId" : String,
-    "LaunchConfigurationName" : String,
-    "LoadBalancerNames" : [ String, ... ],
-    "MaxSize" : String,
-    "MetricsCollection" : [ MetricsCollection, ... ]
-    "MinSize" : String,
-    "NotificationConfigurations" : [ NotificationConfigurations, ... ],
-    "PlacementGroup" : String,
-    "Tags" : [ Auto Scaling Tag, ..., ],
-    "TargetGroupARNs" : [ String, ... ],
-    "TerminationPolicies" : [ String, ..., ],
-    "VPCZoneIdentifier" : [ String, ... ]
-  }
+   "Type" : "AWS::AutoScaling::AutoScalingGroup",
+   "Properties" : {
+      "AvailabilityZones" : [ String, ... ],
+      "Cooldown" : String,
+      "DesiredCapacity" : String,
+      "HealthCheckGracePeriod" : Integer,
+      "HealthCheckType" : String,
+      "InstanceId" : String,
+      "LaunchConfigurationName" : String,
+      "LoadBalancerNames" : [ String, ... ],
+      "MaxSize" : String,
+      "MetricsCollection" : [ MetricsCollection, ... ]
+      "MinSize" : String,
+      "NotificationConfigurations" : [ NotificationConfigurations, ... ],
+      "PlacementGroup" : String,
+      "Tags" : [ Auto Scaling Tag, ... ],
+      "TargetGroupARNs" : [ String, ... ],
+      "TerminationPolicies" : [ String, ..., ],
+      "VPCZoneIdentifier" : [ String, ... ]
+   }
 }

--- a/specs/CloudFormation-Authentication.cf
+++ b/specs/CloudFormation-Authentication.cf
@@ -1,18 +1,17 @@
 {
   "Type": "AWS::CloudFormation::Authentication",
   "Properties" : {
-   "Type" : "AWS::CloudFormation::Authentication" {
-      "String" : {
-         "accessKeyId" : String,
-         "buckets" : [ String, ... ],
-         "password" : String,
-         "secretKey" : String,
-         "type" : String,
-         "uris" : [ String, ... ],
-         "username" : String,
-         "roleName" : String
-      },
-      ...
-   }
+  "Type" : "AWS::CloudFormation::Authentication" {
+    "String" : {
+      "accessKeyId" : String,
+      "buckets" : [ String, ... ],
+      "password" : String,
+      "secretKey" : String,
+      "type" : String,
+      "uris" : [ String, ... ],
+      "username" : String,
+      "roleName" : String
+    }
+  }
 }
 }

--- a/specs/CloudFormation-CustomResource.cf
+++ b/specs/CloudFormation-CustomResource.cf
@@ -1,5 +1,5 @@
 {
-   "Type" : "AWS::CloudFormation::CustomResource",
+   "Type" : "Custom::String",
    "Version" : "1.0",
    "Properties" : {
       "ServiceToken" : String,

--- a/specs/EC2-Instance.cf
+++ b/specs/EC2-Instance.cf
@@ -21,7 +21,7 @@
       "SecurityGroupIds" : [ String, ... ],
       "SecurityGroups" : [ String, ... ],
       "SourceDestCheck" : Boolean,
-      "SsmAssociations" : [ SSMAssociation, ... ]
+      "SsmAssociations" : [ SSMAssociation, ... ],
       "SubnetId" : String,
       "Tags" : [ Resource Tag, ... ],
       "Tenancy" : String,

--- a/specs/EC2-SecurityGroupEgress.cf
+++ b/specs/EC2-SecurityGroupEgress.cf
@@ -1,11 +1,11 @@
 {
-  "Type": "AWS::EC2::SecurityGroupEgress",
+  "Type" : "AWS::EC2::SecurityGroupEgress",
   "Properties" : {
-   "CidrIp" : String,
-   "DestinationSecurityGroupId" : String,
-   "FromPort" : Integer,
-   "GroupId" : String,
-   "IpProtocol" : String,
-   "ToPort" : Integer
-}
+    "CidrIp" : String,
+    "DestinationSecurityGroupId" : String,
+    "FromPort" : Integer,
+    "GroupId" : String,
+    "IpProtocol" : String,
+    "ToPort" : Integer
+  }
 }

--- a/specs/EC2-SecurityGroupIngress.cf
+++ b/specs/EC2-SecurityGroupIngress.cf
@@ -1,14 +1,14 @@
 {
-  "Type": "AWS::EC2::SecurityGroupIngress",
+  "Type" : "AWS::EC2::SecurityGroupIngress",
   "Properties" : {
-   "CidrIp" : String,
-   "FromPort" : Integer,
-   "GroupId" : String,
-   "GroupName" : String,
-   "IpProtocol" : String,
-   "SourceSecurityGroupName" : String,
-   "SourceSecurityGroupId" : String,
-   "SourceSecurityGroupOwnerId" : String,
-   "ToPort" : Integer
-}
+    "CidrIp" : String,
+    "FromPort" : Integer,
+    "GroupId" : String,
+    "GroupName" : String,
+    "IpProtocol" : String,
+    "SourceSecurityGroupName" : String,
+    "SourceSecurityGroupId" : String,
+    "SourceSecurityGroupOwnerId" : String,
+    "ToPort" : Integer
+  }
 }

--- a/specs/EC2-Subnet.cf
+++ b/specs/EC2-Subnet.cf
@@ -5,6 +5,6 @@
       "CidrBlock" : String,
       "MapPublicIpOnLaunch" : Boolean,
       "Tags" : [ Resource Tag, ... ],
-      "VpcId" : { "Ref" : String }
+      "VpcId" : String
    }
 }

--- a/specs/EC2-SubnetNetworkAclAssociation.cf
+++ b/specs/EC2-SubnetNetworkAclAssociation.cf
@@ -1,5 +1,5 @@
 "Type" : "AWS::EC2::SubnetNetworkAclAssociation",
 "Properties" : {
-   "SubnetId" : { String },
-   "NetworkAclId" : { String }
+   "SubnetId" : String,
+   "NetworkAclId" : String
 }

--- a/specs/EC2-SubnetRouteTableAssociation.cf
+++ b/specs/EC2-SubnetRouteTableAssociation.cf
@@ -2,6 +2,6 @@
    "Type" : "AWS::EC2::SubnetRouteTableAssociation",
    "Properties" : {
       "RouteTableId" : String,
-      "SubnetId" : String,
+      "SubnetId" : String
    }
 }

--- a/specs/EC2-VPNConnectionRoute.cf
+++ b/specs/EC2-VPNConnectionRoute.cf
@@ -1,7 +1,7 @@
 {
    "Type" : "AWS::EC2::VPNConnectionRoute",
    "Properties" : {
-      "DestinationCidrBlock" : String
-      "VpnConnectionId" : String,
+      "DestinationCidrBlock" : String,
+      "VpnConnectionId" : String
    }
 }

--- a/specs/ECS-Cluster.cf
+++ b/specs/ECS-Cluster.cf
@@ -1,6 +1,6 @@
 {
-  "Type": "AWS::ECS::Cluster",
+  "Type" : "AWS::ECS::Cluster",
   "Properties" : {
-  "Type" : "AWS::ECS::Cluster"
-}
+    "ClusterName" : String
+  }
 }

--- a/specs/ECS-TaskDefinition.cf
+++ b/specs/ECS-TaskDefinition.cf
@@ -2,6 +2,8 @@
   "Type" : "AWS::ECS::TaskDefinition",
   "Properties" : {
     "ContainerDefinitions" : [ Container Definition, ... ],
+    "Family" : String,
+    "TaskRoleArn" : String,
     "Volumes" : [ Volume Definition, ... ]
   }
 }

--- a/specs/ElastiCache-SubnetGroup.cf
+++ b/specs/ElastiCache-SubnetGroup.cf
@@ -1,4 +1,4 @@
-"SubnetGroup" : {
+{
     "Type" : "AWS::ElastiCache::SubnetGroup",
     "Properties" : {
         "Description" : String,

--- a/specs/Elasticsearch-Domain.cf
+++ b/specs/Elasticsearch-Domain.cf
@@ -6,6 +6,7 @@
     "DomainName" : String,
     "EBSOptions" : EBS Options,
     "ElasticsearchClusterConfig" : Elasticsearch Cluster Config,
+    "ElasticsearchVersion" : String,
     "SnapshotOptions" : Snapshot Options,
     "Tags" : [ Resource Tag, ... ]
   }

--- a/specs/IAM-Group.cf
+++ b/specs/IAM-Group.cf
@@ -1,9 +1,9 @@
 {
-  "Type": "AWS::IAM::Group",
-  "Properties": {
-    "GroupName": String,
-    "ManagedPolicyArns": [ String, ... ],
-    "Path": String,
-    "Policies": [ Policies, ... ]
-  }
+   "Type": "AWS::IAM::Group",
+   "Properties": {
+      "GroupName": String,
+      "ManagedPolicyArns": [ String, ... ],
+      "Path": String,
+      "Policies": [ Policies, ... ]
+   }
 }

--- a/specs/IAM-Policy.cf
+++ b/specs/IAM-Policy.cf
@@ -1,10 +1,10 @@
 {
-   "Type": "AWS::IAM::Policy",
-   "Properties": {
-      "Groups" : [ String, ... ],
-      "PolicyDocument" : JSON object,
-      "PolicyName" : String,
-      "Roles" : [ String, ... ],
-      "Users" : [ String, ... ]
-   }
+  "Type" : "AWS::IAM::Policy"
+  "Properties" : { 
+    "Groups" : [ String, ... ],
+    "PolicyDocument" : JSON object,
+    "PolicyName" : String,
+    "Roles" : [ String, ... ],
+    "Users" : [ String, ... ]
+  }
 }

--- a/specs/IoT-Thing.cf
+++ b/specs/IoT-Thing.cf
@@ -1,6 +1,6 @@
 {
    "Type": "AWS::IoT::Thing",
-   "Properties" : {
+   "Properties": {
       "AttributePayload": { String:String, ... },
       "ThingName": String
     }

--- a/specs/KMS-Alias.cf
+++ b/specs/KMS-Alias.cf
@@ -1,0 +1,7 @@
+{
+  "Type" : "AWS::KMS::Alias",
+  "Properties" : {
+    "AliasName" : String,
+    "TargetKeyId" : String
+  }
+}

--- a/specs/KMS-Key.cf
+++ b/specs/KMS-Key.cf
@@ -4,6 +4,6 @@
     "Description" : String,
     "Enabled" : Boolean,
     "EnableKeyRotation" : Boolean,
-    "KeyPolicy" : JSON object    
+    "KeyPolicy" : JSON object
   }
 }

--- a/specs/RDS-DBClusterParameterGroup.cf
+++ b/specs/RDS-DBClusterParameterGroup.cf
@@ -1,5 +1,5 @@
 {
-  "Type": "AWS::RDS::DBClusterParameterGroup",
+  "Type" : "AWS::RDS::DBClusterParameterGroup",
   "Properties" : {
     "Description" : String,
     "Family" : String,

--- a/specs/RDS-DBInstance.cf
+++ b/specs/RDS-DBInstance.cf
@@ -23,6 +23,8 @@
     "LicenseModel" : String,
     "MasterUsername" : String,
     "MasterUserPassword" : String,
+    "MonitoringInterval" : Integer,
+    "MonitoringRoleArn" : String,
     "MultiAZ" : Boolean,
     "MonitoringInterval" : Integer,
     "MonitoringRoleArn" : String,
@@ -34,7 +36,7 @@
     "SourceDBInstanceIdentifier" : String,
     "StorageEncrypted" : Boolean,
     "StorageType" : String,
-    "Tags" : [ Resource Tag, ..., ],
+    "Tags" : [ Resource Tag, ... ],
     "VPCSecurityGroups" : [ String, ... ]
   }
 }

--- a/specs/RDS-DBParameterGroup.cf
+++ b/specs/RDS-DBParameterGroup.cf
@@ -1,5 +1,5 @@
 {
-   "Type": "AWS::RDS::DBParameterGroup",
+   "Type" : "AWS::RDS::DBParameterGroup",
    "Properties" : {
       "Description" : String,
       "Family" : String,

--- a/specs/RDS-DBSecurityGroupIngress.cf
+++ b/specs/RDS-DBSecurityGroupIngress.cf
@@ -1,10 +1,9 @@
 {
-  "Type": "AWS::RDS::DBSecurityGroupIngress",
+  "Type" : "AWS::RDS::DBSecurityGroupIngress",
   "Properties" : {
    "CIDRIP": String,
    "DBSecurityGroupName": String,
    "EC2SecurityGroupId": String,
    "EC2SecurityGroupName": String,
    "EC2SecurityGroupOwnerId": String
-}
 }

--- a/specs/RDS-OptionGroup.cf
+++ b/specs/RDS-OptionGroup.cf
@@ -1,5 +1,5 @@
 {
-   "Type": "AWS::RDS::OptionGroup",
+   "Type" : "AWS::RDS::OptionGroup",
    "Properties" : {
       "EngineName" : String,
       "MajorEngineVersion" : String,

--- a/specs/Redshift-Cluster.cf
+++ b/specs/Redshift-Cluster.cf
@@ -1,6 +1,6 @@
 {
-  "Type": "AWS::Redshift::Cluster",
-  "Properties": {
+  "Type" : "AWS::Redshift::Cluster",
+  "Properties" : {
     "AllowVersionUpgrade" : Boolean,
     "AutomatedSnapshotRetentionPeriod" : Integer,
     "AvailabilityZone" : String,

--- a/specs/Redshift-ClusterParameterGroup.cf
+++ b/specs/Redshift-ClusterParameterGroup.cf
@@ -1,6 +1,6 @@
 {
-  "Type": "AWS::Redshift::ClusterParameterGroup",
-  "Properties": {
+  "Type" : "AWS::Redshift::ClusterParameterGroup",
+  "Properties" : {
     "Description" : String,
     "ParameterGroupFamily" : String,
     "Parameters" : [ Parameter, ... ]

--- a/specs/Redshift-ClusterSecurityGroup.cf
+++ b/specs/Redshift-ClusterSecurityGroup.cf
@@ -1,6 +1,6 @@
 {
-  "Type": "AWS::Redshift::ClusterSecurityGroup",
-  "Properties": {
+  "Type" : "AWS::Redshift::ClusterSecurityGroup",
+  "Properties" : {
     "Description" : String
   }
 }

--- a/specs/Redshift-ClusterSecurityGroupIngress.cf
+++ b/specs/Redshift-ClusterSecurityGroupIngress.cf
@@ -1,6 +1,6 @@
 {
-  "Type": "AWS::Redshift::ClusterSecurityGroupIngress",
-  "Properties": {
+  "Type" : "AWS::Redshift::ClusterSecurityGroupIngress",
+  "Properties" : {
     "ClusterSecurityGroupName" : String,
     "CIDRIP" : String,
     "EC2SecurityGroupName" : String,

--- a/specs/Redshift-ClusterSubnetGroup.cf
+++ b/specs/Redshift-ClusterSubnetGroup.cf
@@ -1,6 +1,6 @@
 {
-  "Type": "AWS::Redshift::ClusterSubnetGroup",
-  "Properties": {
+  "Type" : "AWS::Redshift::ClusterSubnetGroup",
+  "Properties" : {
     "Description" : String,
     "SubnetIds" : [ String, ... ]
   }

--- a/specs/Route53-HealthCheck.cf
+++ b/specs/Route53-HealthCheck.cf
@@ -1,7 +1,7 @@
 {
   "Type" : "AWS::Route53::HealthCheck",
   "Properties" : {
-    "HealthCheckConfig" : { HealthCheckConfig },
+    "HealthCheckConfig" : HealthCheckConfig,
     "HealthCheckTags" : [ HealthCheckTags, ... ]
   }
 }

--- a/specs/Route53-HostedZone.cf
+++ b/specs/Route53-HostedZone.cf
@@ -1,7 +1,7 @@
 {
   "Type" : "AWS::Route53::HostedZone",
   "Properties" : {
-    "HostedZoneConfig" : { HostedZoneConfig },
+    "HostedZoneConfig" : HostedZoneConfig,
     "HostedZoneTags" : [  HostedZoneTags, ... ],
     "Name" : String,
     "VPCs" : [ HostedZoneVPCs, ... ]

--- a/specs/Route53-RecordSet.cf
+++ b/specs/Route53-RecordSet.cf
@@ -4,7 +4,7 @@
     "AliasTarget" : AliasTarget,
     "Comment" : String,
     "Failover" : String,
-    "GeoLocation" : { GeoLocation },
+    "GeoLocation" : GeoLocation,
     "HealthCheckId" : String,
     "HostedZoneId" : String,
     "HostedZoneName" : String,

--- a/specs/SDB-Domain.cf
+++ b/specs/SDB-Domain.cf
@@ -1,6 +1,6 @@
-"MySDBDomain" : {
-    "Type" : "AWS::SDB::Domain",
-    "Properties" : {
-        "Description" : "Other than this AWS CloudFormation Description property, SDB Domains have no properties."
-    }
+{
+  "Type" : "AWS::SDB::Domain",
+  "Properties" : {
+    "Description" : String
+  }
 }

--- a/specs/SQS-Queue.cf
+++ b/specs/SQS-Queue.cf
@@ -1,6 +1,6 @@
 {
-   "Type": "AWS::SQS::Queue",
-   "Properties": {
+   "Type" : "AWS::SQS::Queue",
+   "Properties" : {
       "DelaySeconds": Integer,
       "MaximumMessageSize": Integer,
       "MessageRetentionPeriod": Integer,

--- a/test/full_stack_test.rb
+++ b/test/full_stack_test.rb
@@ -16,7 +16,8 @@ class FullStackTest < Minitest::Test
 
   def test_to_cf
     stack = Humidifier::Stack.new(static_resources.merge(enumerable_resources))
-    assert_equal EXPECTED_CF, JSON.parse(stack.to_cf)
+    assert_equal EXPECTED_CF, JSON.parse(stack.to_cf(:json))
+    assert_equal EXPECTED_CF, YAML.load(stack.to_cf(:yaml))
   end
 
   private


### PR DESCRIPTION
* Adds support for the KMS Key class that was released yesterday
* Adds support for YAML serialization on Humidifier::Stack#to_cf

        security_group = Humidifier::EC2::SecurityGroup.new(group_description: 'Test')
        stack = Humidifier::Stack.new(name: 'Test-Stack', resources: { 'SecurityGroup' => security_group })
        puts stack.to_cf(:yaml)

* Updates other specs (looks like AWS cleaned up a lot of things)