### PR TITLE
Favor sdkv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ Once stacks have the appropriate resources, you can query AWS to handle all stac
 
 Humidifier assumes you have an `aws-sdk` gem installed when you call these operations. It detects the version of the gem you have installed and uses the appropriate API depending on what is available. If Humidifier cannot find any way to use the AWS SDK, it will warn you on every API call and simply return false.
 
+You can also manually specify the version of the SDK that you want to use, in the case that you have both gems in your load path. In that case, you would specify it on the Humidifier configuration object:
+
+```ruby
+Humidifier.configure do |config|
+  config.sdk_version = 1
+end
+```
+
 #### CloudFormation functions
 
 You can use CFN intrinsic functions and references using `Humidifier.fn.[name]` and `Humidifier.ref`. Those will build appropriate structures that know how to be dumped to CFN syntax appropriately.

--- a/lib/humidifier/configuration.rb
+++ b/lib/humidifier/configuration.rb
@@ -14,16 +14,27 @@ on the top-level Humidifier object like so:
     end
 MSG
 
-    attr_accessor :s3_bucket, :s3_prefix
+    attr_accessor :s3_bucket, :s3_prefix, :sdk_version
 
     def initialize(opts = {})
-      self.s3_bucket = opts[:s3_bucket]
-      self.s3_prefix = opts[:s3_prefix]
+      self.s3_bucket   = opts[:s3_bucket]
+      self.s3_prefix   = opts[:s3_prefix]
+      self.sdk_version = opts[:sdk_version]
     end
 
     # raise an error unless the s3_bucket field is set
     def ensure_upload_configured!(payload)
       raise UPLOAD_MESSAGE.gsub('%{identifier}', payload.identifier) if s3_bucket.nil?
+    end
+
+    # true if the sdk_version option is set to 1 or '1'
+    def sdk_version_1?
+      sdk_version.to_s == '1'
+    end
+
+    # true if the sdk_version option is set to 2 or '2'
+    def sdk_version_2?
+      sdk_version.to_s == '2'
     end
   end
 end

--- a/lib/humidifier/version.rb
+++ b/lib/humidifier/version.rb
@@ -1,4 +1,4 @@
 module Humidifier
   # Gem version
-  VERSION = '0.6.1'.freeze
+  VERSION = '0.7.0'.freeze
 end

--- a/test/aws_adapters/base_test.rb
+++ b/test/aws_adapters/base_test.rb
@@ -70,7 +70,7 @@ class BaseTest < Minitest::Test
       end
     end
 
-    with_config('test.s3.bucket', 'prefix/') do
+    with_config(s3_bucket: 'test.s3.bucket', s3_prefix: 'prefix/') do
       assert_equal 'prefix/name.json', fake_sdk.new.upload(payload(identifier: 'name'))
     end
   end

--- a/test/aws_adapters/sdkv1_test.rb
+++ b/test/aws_adapters/sdkv1_test.rb
@@ -55,7 +55,7 @@ class SDKV1Test < Minitest::Test
   end
 
   def test_upload
-    with_config('test.s3.bucket') do
+    with_config(s3_bucket: 'test.s3.bucket') do
       with_sdk_v1_loaded do |sdk|
         upload_expectations
         sdk.upload(payload(identifier: 'identifier', to_cf: 'body'))

--- a/test/aws_adapters/sdkv2_test.rb
+++ b/test/aws_adapters/sdkv2_test.rb
@@ -65,7 +65,7 @@ class SDKV2Test < Minitest::Test
   end
 
   def test_upload
-    with_config('test.s3.bucket') do
+    with_config(s3_bucket: 'test.s3.bucket') do
       with_sdk_v2_loaded do |sdk|
         SdkSupport.expect(:config, [], SdkSupport.double)
         SdkSupport.expect(:update, [region: Humidifier::AwsShim::REGION])

--- a/test/aws_shim_test.rb
+++ b/test/aws_shim_test.rb
@@ -13,19 +13,30 @@ class AwsShimTest < Minitest::Test
     mock.verify
   end
 
-  def test_initialize_noop
-    assert_kind_of Humidifier::AwsAdapters::Noop, Humidifier::AwsShim.new.shim
+  def test_initialize_sdk_version_1?
+    with_config(sdk_version: 1) { assert_shim(:SDKV1) }
   end
 
-  def test_initialize_sdk_v1
-    with_sdk_v1_loaded do
-      assert_kind_of Humidifier::AwsAdapters::SDKV1, Humidifier::AwsShim.new.shim
-    end
+  def test_initialize_sdk_version_2?
+    with_config(sdk_version: 2) { assert_shim(:SDKV2) }
   end
 
-  def test_initialize_sdk_v2
-    with_sdk_v2_loaded do
-      assert_kind_of Humidifier::AwsAdapters::SDKV2, Humidifier::AwsShim.new.shim
-    end
+  def test_guess_sdk_noop
+    assert_shim(:Noop)
+  end
+
+  def test_guess_sdk_sdk_v1
+    with_sdk_v1_loaded { assert_shim(:SDKV1) }
+  end
+
+  def test_guess_sdk_sdk_v2
+    with_sdk_v2_loaded { assert_shim(:SDKV2) }
+  end
+
+  private
+
+  def assert_shim(kind)
+    expected = Humidifier::AwsAdapters.const_get(kind)
+    assert_kind_of expected, Humidifier::AwsShim.new.shim
   end
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -3,17 +3,33 @@ require 'test_helper'
 class ConfigurationTest < Minitest::Test
 
   def test_ensure_upload_configured!
-    config = Humidifier::Configuration.new
     error =
       assert_raises RuntimeError do
-        config.ensure_upload_configured!(payload(identifier: 'foobar'))
+        build.ensure_upload_configured!(payload(identifier: 'foobar'))
       end
     assert_match(/foobar/, error.message)
   end
 
   def test_ensure_upload_configured_passes
-    config = Humidifier::Configuration.new
-    config.s3_bucket = Object.new
+    config = build(s3_bucket: Object.new)
     config.ensure_upload_configured!(payload(identifier: 'foobar'))
+  end
+
+  def test_sdk_version_1?
+    assert build(sdk_version: 1).sdk_version_1?
+    assert build(sdk_version: '1').sdk_version_1?
+    refute build(sdk_version: 'foobar').sdk_version_1?
+  end
+
+  def test_sdk_version_2?
+    assert build(sdk_version: 2).sdk_version_2?
+    assert build(sdk_version: '2').sdk_version_2?
+    refute build(sdk_version: 'foobar').sdk_version_2?
+  end
+
+  private
+
+  def build(options = {})
+    Humidifier::Configuration.new(options)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,8 +31,8 @@ Minitest::Test.send(:include, SdkSupport::Helpers)
 
 # extra methods for testing config and serializers
 Minitest::Test.send(:include, Module.new do
-  def with_config(s3_bucket, s3_prefix = nil, &block)
-    config = Humidifier::Configuration.new(s3_bucket: s3_bucket, s3_prefix: s3_prefix)
+  def with_config(options = {}, &block)
+    config = Humidifier::Configuration.new(options)
     Humidifier.stub(:config, config, &block)
   end
 


### PR DESCRIPTION
This PR does two things. The first is that in AwsShim, it changes the behavior to favor AWS SDK v2 if it's in the load path over v1. Presumably if you have both in your load path you want the most recent. The other thing that this PR does is allow you to manually specify which version of the SDK to use through the config object. That would look like:

    Humidifier.configure { |config| config.sdk_version = 1 }