### PR TITLE
Subprop usage

### DIFF
--- a/lib/humidifier/props/list_prop.rb
+++ b/lib/humidifier/props/list_prop.rb
@@ -4,6 +4,11 @@ module Humidifier
     class ListProp < Base
       attr_reader :subprop
 
+      # CFN stack syntax
+      def to_cf(list)
+        [key, list.map { |value| subprop.to_cf(value).last }]
+      end
+
       # Valid if the value is whitelisted or every value in the list is valid on the subprop
       def valid?(list)
         whitelisted_value?(list) || (list.is_a?(Enumerable) && list.all? { |value| subprop.valid?(value) })

--- a/lib/humidifier/props/map_prop.rb
+++ b/lib/humidifier/props/map_prop.rb
@@ -4,6 +4,15 @@ module Humidifier
     class MapProp < Base
       attr_reader :subprop
 
+      # CFN stack syntax
+      def to_cf(map)
+        dumped =
+          Utils.enumerable_to_h(map) do |(subkey, subvalue)|
+            [subkey, subprop.to_cf(subvalue).last]
+          end
+        [key, dumped]
+      end
+
       # Valid if the value is whitelisted or every value in the map is valid on the subprop
       def valid?(map)
         whitelisted_value?(map) || (map.is_a?(Hash) && map.values.all? { |value| subprop.valid?(value) })

--- a/lib/humidifier/props/structure_prop.rb
+++ b/lib/humidifier/props/structure_prop.rb
@@ -4,6 +4,15 @@ module Humidifier
     class StructureProp < Base
       attr_reader :subprops
 
+      # CFN stack syntax
+      def to_cf(value)
+        dumped =
+          Utils.enumerable_to_h(value) do |(subkey, subvalue)|
+            subprops[subkey.to_s].to_cf(subvalue)
+          end
+        [key, dumped]
+      end
+
       # true if the value is whitelisted or Hash and all keys are valid for their corresponding props
       def valid?(struct)
         whitelisted_value?(struct) ||
@@ -17,7 +26,7 @@ module Humidifier
         type = spec['ItemType'] || spec['Type']
         @subprops =
           Utils.enumerable_to_h(substructs[type]['Properties']) do |(key, config)|
-            subprop = config['ItemType'] == type ? self : Props.from(nil, config, substructs)
+            subprop = config['ItemType'] == type ? self : Props.from(key, config, substructs)
             [Utils.underscore(key), subprop]
           end
       end

--- a/lib/humidifier/version.rb
+++ b/lib/humidifier/version.rb
@@ -1,4 +1,4 @@
 module Humidifier
   # Gem version
-  VERSION = '1.0.2'.freeze
+  VERSION = '1.0.3'.freeze
 end

--- a/test/integration_test.json
+++ b/test/integration_test.json
@@ -1,0 +1,78 @@
+{
+  "Resources": {
+    "Distribution": {
+      "Type": "AWS::CloudFront::Distribution",
+      "Properties": {
+        "DistributionConfig" : {
+          "Origins" : [ {
+            "DomainName" : "mybucket.s3.amazonaws.com",
+            "Id" : "myS3Origin",
+            "S3OriginConfig" : {
+              "OriginAccessIdentity" : "origin-access-identity/cloudfront/E127EXAMPLE51Z"
+            }
+          }],
+          "Enabled" : true,
+          "Comment" : "Some comment",
+          "DefaultRootObject" : "index.html",
+          "Logging" : {
+            "IncludeCookies" : false,
+            "Bucket" : "mylogs.s3.amazonaws.com",
+            "Prefix" : "myprefix"
+          },
+          "Aliases" : [ "mysite.example.com", "yoursite.example.com" ],
+          "DefaultCacheBehavior" : {
+            "AllowedMethods" : [ "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT" ],
+            "TargetOriginId" : "myS3Origin",
+            "ForwardedValues" : {
+              "QueryString" : false,
+              "Cookies" : { "Forward" : "none" }
+            },
+            "TrustedSigners" : [ "1234567890EX", "1234567891EX" ],
+            "ViewerProtocolPolicy" : "allow-all"
+          },
+          "PriceClass" : "PriceClass_200",
+          "Restrictions" : {
+              "GeoRestriction" : {
+                "RestrictionType" : "whitelist",
+                "Locations" : [ "AQ", "CV" ]
+              }
+          },
+          "ViewerCertificate" : { "CloudFrontDefaultCertificate" : true }
+        }
+      }
+    },
+    "SpotFleet": {
+      "Type": "AWS::EC2::SpotFleet",
+      "Properties": {
+        "SpotFleetRequestConfigData": {
+          "IamFleetRole": { "Ref": "IAMFleetRole" },
+          "SpotPrice": "1000",
+          "TargetCapacity": { "Ref": "TargetCapacity" },
+          "LaunchSpecifications": [
+          {
+            "EbsOptimized": false,
+            "InstanceType": { "Ref": "InstanceType" },
+            "ImageId": { "Fn::FindInMap": [ "AWSRegionArch2AMI", { "Ref": "AWS::Region" },
+                         { "Fn::FindInMap": [ "AWSInstanceType2Arch", { "Ref": "InstanceType" }, "Arch" ] }
+                       ]},
+            "SubnetId": { "Ref": "Subnet1" },
+            "WeightedCapacity": 8
+          },
+          {
+            "EbsOptimized": true,
+            "InstanceType": { "Ref": "InstanceType" },
+            "ImageId": { "Fn::FindInMap": [ "AWSRegionArch2AMI", { "Ref": "AWS::Region" },
+                         { "Fn::FindInMap": [ "AWSInstanceType2Arch", { "Ref": "InstanceType" }, "Arch" ] }
+                       ]},
+            "Monitoring": { "Enabled": true },
+            "SecurityGroups": [ { "GroupId": { "Fn::GetAtt": [ "SG0", "GroupId" ] } } ],
+            "SubnetId": { "Ref": "Subnet0" },
+            "IamInstanceProfile": { "Arn": { "Fn::GetAtt": [ "RootInstanceProfile", "Arn" ] } },
+            "WeightedCapacity": 8
+          }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -1,0 +1,92 @@
+require 'test_helper'
+
+# rubocop:disable Metrics/MethodLength
+class IntegrationTest < Minitest::Test
+  def test_to_cf
+    resources = { 'Distribution' => distribution, 'SpotFleet' => spot_fleet }
+    stack = Humidifier::Stack.new(name: 'Test-Stack', resources: resources)
+
+    expected = JSON.parse(File.read('test/integration_test.json'))
+    assert_equal expected, JSON.parse(stack.to_cf)
+  end
+
+  private
+
+  # from http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/quickref-cloudfront.html
+  def distribution
+    Humidifier::CloudFront::Distribution.new(
+      distribution_config: {
+        origins: [{
+          domain_name: 'mybucket.s3.amazonaws.com',
+          id: 'myS3Origin',
+          s3_origin_config: { origin_access_identity: 'origin-access-identity/cloudfront/E127EXAMPLE51Z' }
+        }],
+        enabled: true,
+        comment: 'Some comment',
+        default_root_object: 'index.html',
+        logging: {
+          include_cookies: false,
+          bucket: 'mylogs.s3.amazonaws.com',
+          prefix: 'myprefix'
+        },
+        aliases: %w[mysite.example.com yoursite.example.com],
+        default_cache_behavior: {
+          allowed_methods: %w[DELETE GET HEAD OPTIONS PATCH POST PUT],
+          target_origin_id: 'myS3Origin',
+          forwarded_values: {
+            query_string: false,
+            cookies: { forward: 'none' }
+          },
+          trusted_signers: %w[1234567890EX 1234567891EX],
+          viewer_protocol_policy: 'allow-all'
+        },
+        price_class: 'PriceClass_200',
+        restrictions: {
+          geo_restriction: {
+            restriction_type: 'whitelist',
+            locations: %w[AQ CV]
+          }
+        },
+        viewer_certificate: { cloud_front_default_certificate: true }
+      }
+    )
+  end
+
+  def launch_specification
+    image_id = [
+      'AWSRegionArch2AMI',
+      Humidifier.ref('AWS::Region'),
+      Humidifier.fn.find_in_map(['AWSInstanceType2Arch', Humidifier.ref('InstanceType'), 'Arch'])
+    ]
+
+    {
+      instance_type: Humidifier.ref('InstanceType'),
+      image_id: Humidifier.fn.find_in_map(image_id),
+      weighted_capacity: 8
+    }
+  end
+
+  # from http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-spotfleet.html
+  def spot_fleet
+    Humidifier::EC2::SpotFleet.new(
+      spot_fleet_request_config_data: {
+        iam_fleet_role: Humidifier.ref('IAMFleetRole'),
+        spot_price: '1000',
+        target_capacity: Humidifier.ref('TargetCapacity'),
+        launch_specifications: [
+          launch_specification.merge(
+            ebs_optimized: false,
+            subnet_id: Humidifier.ref('Subnet1')
+          ),
+          launch_specification.merge(
+            ebs_optimized: true,
+            monitoring: { enabled: true },
+            security_groups: [{ group_id: Humidifier.fn.get_att(%w[SG0 GroupId]) }],
+            subnet_id: Humidifier.ref('Subnet0'),
+            iam_instance_profile: { arn: Humidifier.fn.get_att(%w[RootInstanceProfile Arn]) }
+          )
+        ]
+      }
+    )
+  end
+end

--- a/test/props/list_prop_test.rb
+++ b/test/props/list_prop_test.rb
@@ -19,6 +19,11 @@ module Props
       refute build.valid?([1, 'foo'])
     end
 
+    def test_to_cf
+      assert_equal ['Test', [1, 2]], build.to_cf([1, 2])
+      assert_equal ['Test', [1, 2]], build.to_cf([1, 2])
+    end
+
     private
 
     def build

--- a/test/props/map_prop_test.rb
+++ b/test/props/map_prop_test.rb
@@ -20,6 +20,11 @@ module Props
       refute build.valid?('foo' => 1, 'bar' => '2')
     end
 
+    def test_to_cf
+      value = { 'Foo' => 1, 'Bar' => 2 }
+      assert_equal ['Test', value], build.to_cf(value)
+    end
+
     private
 
     def build

--- a/test/props/structure_prop_test.rb
+++ b/test/props/structure_prop_test.rb
@@ -16,15 +16,19 @@ module Props
     end
 
     def test_subprop
-      assert build.valid?(alpha: { beta: 'gamma' })
-      refute build.valid?(alpha: { beta: 1 })
+      assert build.valid?(beta: 'gamma')
+      refute build.valid?(beta: 1)
+    end
+
+    def test_to_cf
+      assert_equal ['Alpha', { 'Beta' => 'gamma' }], build.to_cf(beta: 'gamma')
     end
 
     private
 
     def build
       substructs = { 'Sub' => { 'Properties' => { 'Beta' => { 'PrimitiveType' => 'String' } } } }
-      Humidifier::Props::MapProp.new('Alpha', { 'Type' => 'Sub' }, substructs)
+      Humidifier::Props::StructureProp.new('Alpha', { 'Type' => 'Sub' }, substructs)
     end
   end
 end


### PR DESCRIPTION
When ListProp, MapProp, and StructureProp were dumping their values to CloudFormation syntax, they weren't giving their sub prop objects the ability to do their own serialization. Therefore a "TagList" ListProp with a hash property would look like:

    TagList:
    - key: 'key1'
      value: 'value1'
    - key: 'key2'
      value: 'value2'

as opposed to:

    TagList:
    - Key: 'key1'
      Value: 'value1'
    - Key: 'key2'
      Value: 'value2'

This commit also adds a larger integration test that will catch these kinds of things in the future.