### PR TITLE
`force_upload`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,23 @@ Humidifier.configure do |config|
 end
 ```
 
+### Forcing uploading
+
+You can force a stack to upload its template to S3 regardless of the size of the template. This is a useful option if you're going to be deploying multiple
+copies of a template or you just generally want a backup. You can set this option on a per-stack basis:
+
+```ruby
+stack.deploy(force_upload: true)
+```
+
+or globally, but setting the configuration option:
+
+```ruby
+Humidifier.configure do |config|
+  config.force_upload = true
+end
+```
+
 ## Development
 
 To get started, ensure you have ruby installed, version 2.1 or later. From there, install the `bundler` gem: `gem install bundler` and then `bundle install` in the root of the repository.

--- a/lib/humidifier/configuration.rb
+++ b/lib/humidifier/configuration.rb
@@ -15,12 +15,31 @@ Humidifier object like so:
     end
 MSG
 
-    attr_accessor :s3_bucket, :s3_prefix, :sdk_version
+    # If true, always upload the CloudFormation template to the configured S3
+    # destination. A useful option if you're going to be deploying multiple
+    # copies of a template or you just generally want a backup.
+    attr_accessor :force_upload
+
+    # The S3 bucket to which to deploy CloudFormation templates when
+    # `always_upload` is set to true or the template is too big for a string
+    # literal.
+    attr_accessor :s3_bucket
+
+    # An optional prefix for the stack names.
+    attr_accessor :s3_prefix
+
+    # By default, `humidifier` will attempt to determine which SDK you have
+    # loaded. (There's not really a story for peer dependencies with bundler).
+    # If you want to enforce a specific version (for instance if you have both
+    # `aws-sdk-v1` and `aws-sdk` but want to use the former) you can set this
+    # variable to `1`.
+    attr_accessor :sdk_version
 
     def initialize(opts = {})
-      self.s3_bucket   = opts[:s3_bucket]
-      self.s3_prefix   = opts[:s3_prefix]
-      self.sdk_version = opts[:sdk_version]
+      @force_upload = opts[:force_upload]
+      @s3_bucket    = opts[:s3_bucket]
+      @s3_prefix    = opts[:s3_prefix]
+      @sdk_version  = opts[:sdk_version]
     end
 
     # raise an error unless the s3_bucket field is set


### PR DESCRIPTION
Allow forcing templates to be uploaded to S3 regardless of stack size. This can be done on a per-stack basis by passing the `force_upload: true` parameter to the `deploy` function or by setting the global configuration setting, as in `Humidifier.configure { |config| config.force_upload = true }`.